### PR TITLE
fix: prevent closing punctuation from starting a line

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -765,7 +765,8 @@ async def generate_handwriting_impl(
         line_spacing_sigma=int(data["line_spacing_sigma"]),  # 行间距随机扰动
         font_size_sigma=int(data["font_size_sigma"]),  # 字体大小随机扰动
         word_spacing_sigma=int(data["word_spacing_sigma"]),  # 字间距随机扰动
-        end_chars="，。",  # 防止特定字符因排版算法的自动换行而出现在行首
+        # Keep handright's full default end_chars set so closing punctuation,
+        # such as right quotes, stays on the previous line.
         perturb_x_sigma=int(data["perturb_x_sigma"]),  # 笔画横向偏移随机扰动
         perturb_y_sigma=int(data["perturb_y_sigma"]),  # 笔画纵向偏移随机扰动
         perturb_theta_sigma=float(data["perturb_theta_sigma"]),  # 笔画旋转偏移随机扰动

--- a/backend/tests/test_typography.py
+++ b/backend/tests/test_typography.py
@@ -1,0 +1,51 @@
+import unittest
+from collections import defaultdict
+from pathlib import Path
+from unittest.mock import patch
+
+from PIL import Image, ImageFont
+from handright import Template
+import handright._core as handright_core
+
+
+def _draft_lines(text):
+    font_path = Path(__file__).parents[1] / "font_assets" / "李国夫手写体.ttf"
+    font = ImageFont.truetype(str(font_path), 24)
+    positioned_chars = []
+    original_flow_layout = handright_core._flow_layout
+
+    def record_flow_layout(draw, x, y, char, template, rand):
+        positioned_chars.append((round(y), char))
+        return original_flow_layout(draw, x, y, char, template, rand)
+
+    template = Template(
+        background=Image.new("RGB", (60, 120), "white"),
+        font=font,
+        line_spacing=30,
+        word_spacing=0,
+        line_spacing_sigma=0,
+        font_size_sigma=0,
+        word_spacing_sigma=0,
+        perturb_x_sigma=0,
+        perturb_y_sigma=0,
+        perturb_theta_sigma=0,
+        ink_depth_sigma=0,
+    )
+
+    with patch.object(handright_core, "_flow_layout", record_flow_layout):
+        list(handright_core._draft(text, (template,), seed=1))
+
+    chars_by_line = defaultdict(list)
+    for y, char in positioned_chars:
+        chars_by_line[y].append(char)
+    return ["".join(chars) for chars in chars_by_line.values()]
+
+
+class TypographyTest(unittest.TestCase):
+    def test_closing_punctuation_does_not_start_a_line(self):
+        for punctuation in "，。！？；：、）》】’”":
+            with self.subTest(punctuation=punctuation):
+                self.assertEqual(
+                    _draft_lines(f"丁。{punctuation}后文"),
+                    [f"丁。{punctuation}", "后文"],
+                )

--- a/backend/tests/test_typography.py
+++ b/backend/tests/test_typography.py
@@ -63,7 +63,7 @@ class TypographyTest(unittest.TestCase):
                 )
             )
 
-        expected_end_chars = "，。》？；：’”】｝、！％）,.>?;:]}!%)′″℃℉"
+        expected_end_chars = "，。》？；：’”】｝、！％）,.>?;:]}!%)′″℃℉"  # noqa: RUF001
         self.assertTrue(
             set(expected_end_chars).issubset(captured_template.get_end_chars())
         )

--- a/backend/tests/test_typography.py
+++ b/backend/tests/test_typography.py
@@ -1,51 +1,73 @@
+import asyncio
 import unittest
-from collections import defaultdict
-from pathlib import Path
 from unittest.mock import patch
 
-from PIL import Image, ImageFont
-from handright import Template
-import handright._core as handright_core
+from handright import Template as HandrightTemplate
+from PIL import Image
+
+from app import GenerateHandwritingParams, generate_handwriting_impl
 
 
-def _draft_lines(text):
-    font_path = Path(__file__).parents[1] / "font_assets" / "李国夫手写体.ttf"
-    font = ImageFont.truetype(str(font_path), 24)
-    positioned_chars = []
-    original_flow_layout = handright_core._flow_layout
+class TemplateCaptured(Exception):
+    pass
 
-    def record_flow_layout(draw, x, y, char, template, rand):
-        positioned_chars.append((round(y), char))
-        return original_flow_layout(draw, x, y, char, template, rand)
 
-    template = Template(
-        background=Image.new("RGB", (60, 120), "white"),
-        font=font,
-        line_spacing=30,
-        word_spacing=0,
-        line_spacing_sigma=0,
-        font_size_sigma=0,
-        word_spacing_sigma=0,
-        perturb_x_sigma=0,
-        perturb_y_sigma=0,
-        perturb_theta_sigma=0,
-        ink_depth_sigma=0,
-    )
-
-    with patch.object(handright_core, "_flow_layout", record_flow_layout):
-        list(handright_core._draft(text, (template,), seed=1))
-
-    chars_by_line = defaultdict(list)
-    for y, char in positioned_chars:
-        chars_by_line[y].append(char)
-    return ["".join(chars) for chars in chars_by_line.values()]
+class FakeFont:
+    size = 24
 
 
 class TypographyTest(unittest.TestCase):
-    def test_closing_punctuation_does_not_start_a_line(self):
-        for punctuation in "，。！？；：、）》】’”,.>?;:]}!%)′″℃℉":
-            with self.subTest(punctuation=punctuation):
-                self.assertEqual(
-                    _draft_lines(f"丁。{punctuation}后文"),
-                    [f"丁。{punctuation}", "后文"],
+    def test_app_preserves_handright_default_end_chars(self):
+        params = GenerateHandwritingParams(
+            text="A.) B",
+            font_size="24",
+            line_spacing="30",
+            fill="(0, 0, 0, 255)",
+            left_margin="0",
+            top_margin="0",
+            right_margin="0",
+            bottom_margin="0",
+            word_spacing="0",
+            line_spacing_sigma="0",
+            font_size_sigma="0",
+            word_spacing_sigma="0",
+            perturb_x_sigma="0",
+            perturb_y_sigma="0",
+            perturb_theta_sigma="0",
+            preview="true",
+            width="60",
+            height="120",
+        )
+        captured_template = None
+
+        def capture_template(*args, **kwargs):
+            nonlocal captured_template
+            captured_template = HandrightTemplate(*args, **kwargs)
+            raise TemplateCaptured
+
+        with (
+            patch("app.psutil.cpu_percent", return_value=0),
+            patch(
+                "app.create_notebook_image",
+                return_value=Image.new("RGB", (60, 120), "white"),
+            ),
+            patch("app.ImageFont.truetype", return_value=FakeFont()),
+            patch("app.Template", side_effect=capture_template),
+            self.assertRaises(TemplateCaptured),
+        ):
+            asyncio.run(
+                generate_handwriting_impl(
+                    "http://localhost/",
+                    params,
+                    font_file=b"test-font",
                 )
+            )
+
+        expected_end_chars = "，。》？；：’”】｝、！％）,.>?;:]}!%)′″℃℉"
+        self.assertTrue(
+            set(expected_end_chars).issubset(captured_template.get_end_chars())
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_typography.py
+++ b/backend/tests/test_typography.py
@@ -43,7 +43,7 @@ def _draft_lines(text):
 
 class TypographyTest(unittest.TestCase):
     def test_closing_punctuation_does_not_start_a_line(self):
-        for punctuation in "，。！？；：、）》】’”":
+        for punctuation in "，。！？；：、）》】’”,.>?;:]}!%)′″℃℉":
             with self.subTest(punctuation=punctuation):
                 self.assertEqual(
                     _draft_lines(f"丁。{punctuation}后文"),


### PR DESCRIPTION
## Problem

The backend overrides Handright's complete `end_chars` set with only `，。`. As a result, other closing punctuation—including Chinese quotes and brackets as well as ASCII punctuation—can wrap onto the beginning of the next line.

This is part of the punctuation-wrapping problem reported in #46.

## Root cause

Handright already provides a broader default set of characters that must remain at the end of the previous line. Passing `end_chars="，。"` replaces that default instead of extending it.

## Solution

- Remove the narrow `end_chars` override and use Handright's maintained default.
- Add an application-level regression test that captures the actual `Template` created by the backend.
- Verify the complete Chinese and ASCII closing-punctuation set without relying on local font assets.

## Impact

Closing punctuation stays with the preceding text during automatic wrapping. There are no API or configuration changes.

## Before / after

Both images use the same deterministic settings and anonymous sample text: `丁。”后文` and `ABC.)后文`.

| Before | After |
| --- | --- |
| ![Closing quote and parenthesis wrapped to the next line](https://raw.githubusercontent.com/ejjcc/handwriting-web/45e183d/pr-assets/64/before.png) | ![Closing quote and parenthesis kept with preceding text](https://raw.githubusercontent.com/ejjcc/handwriting-web/45e183d/pr-assets/64/after.png) |

## Validation

- `python -m unittest discover -s tests -p 'test_typography.py' -v`
- Verified the regression test fails against current upstream `main` and passes with this change.
- `python -m compileall -q app.py tests/test_typography.py`
- `git diff --check`

Partially addresses #46. English word tokenization and hyphenation remain outside this PR.