### PR TITLE
fix: remember the local full preview toggle

### DIFF
--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -366,13 +366,14 @@ export default {
       queueFullTimer: null,         // setInterval 句柄
       enableFullPreview: false,
       localStorageItems: ['text', 'fontFile', 'fontSize', 'lineSpacing', 'fill', 'width', 'height', 'marginTop', 'marginBottom', 'marginLeft', 'marginRight', 'selectedFontFileName', 'selectedOption', 'lineSpacingSigma', 'fontSizeSigma', 'wordSpacingSigma', 'perturbXSigma', 'perturbYSigma', 'perturbThetaSigma', 'wordSpacing', 'strikethrough_length_sigma', 'strikethrough_angle_sigma', 'strikethrough_width_sigma', 'strikethrough_probability', 'strikethrough_width', 'ink_depth_sigma', 'isUnderlined', 'enableEnglishSpacing'],
+      persistentUiItems: ['enableFullPreview'],
     };
   },
   created() {
 
     // const localStorageItems = ['text', 'fontFile', 'fontSize', 'lineSpacing', 'fill', 'width', 'height', 'marginTop', 'marginBottom', 'marginLeft', 'marginRight', 'selectedFontFileName', 'selectedOption', 'lineSpacingSigma', 'fontSizeSigma', 'wordSpacingSigma', 'perturbXSigma', 'perturbYSigma', 'perturbThetaSigma', 'wordSpacing'];//, 'backgroundImage', 'selectedImageFileName'
 
-    this.localStorageItems.forEach(item => {
+    [...this.localStorageItems, ...this.persistentUiItems].forEach(item => {
       const value = localStorage.getItem(item);
       if (value !== null && value !== "undefined") {
         try {
@@ -385,6 +386,10 @@ export default {
         console.log('localstorage缺失item:' + item)
       }
     });
+
+    if (typeof this.enableFullPreview !== 'boolean') {
+      this.enableFullPreview = false;
+    }
 
     this.$http.get('/api/fonts_info').then(response => {
       this.options = response.data.map((font, index) => {
@@ -694,6 +699,9 @@ export default {
         localStorage.setItem('enableEnglishSpacing', JSON.stringify(newVal));
       },
       deep: true
+    },
+    enableFullPreview(newVal) {
+      localStorage.setItem('enableFullPreview', JSON.stringify(newVal));
     },
   },
 


### PR DESCRIPTION
## Problem

The development-only **local full preview** toggle resets to off after every page refresh. Repeated preview testing therefore requires enabling the same switch again each time.

The toggle was only held in component state and was omitted from the existing local-storage restoration path.

## Solution

- Restore `enableFullPreview` alongside the existing persisted values.
- Persist changes through a focused watcher.
- Validate the restored value and fall back to `false` when it is not a boolean.
- Keep this UI preference separate from `localStorageItems`, so saving handwriting settings does not bake the development toggle into user presets.

## Behavior and scope

- The preference is local to the current browser and origin.
- The generated preview itself is not cached.
- The default remains off.
- Production behavior is unchanged: full-preview requests remain disabled outside development mode.

## Screenshots

Enabled immediately before refresh:

![Full preview enabled before refresh](https://raw.githubusercontent.com/ejjcc/handwriting-web/6c08eda8d93a3353eabd1f1300f952a29b601272/pr-assets/full-preview-toggle/before-refresh.png)

Still enabled after refresh:

![Full preview still enabled after refresh](https://raw.githubusercontent.com/ejjcc/handwriting-web/6c08eda8d93a3353eabd1f1300f952a29b601272/pr-assets/full-preview-toggle/after-refresh.png)

## Validation

- `npm run lint -- --no-fix`
- `npm run build`
- Browser refresh test: button remains `本地全量预览：开`
- Browser storage check: `enableFullPreview` restores as boolean `true`
- `git diff --check`

Follow-up to #54.
